### PR TITLE
Fix bubble aim issues

### DIFF
--- a/Assets/_Developer/Scenes/SampleScene.unity
+++ b/Assets/_Developer/Scenes/SampleScene.unity
@@ -15288,24 +15288,12 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 96791299733239411, guid: 333d44bb4feca4d4da4ace10c170cea6, type: 3}
-      propertyPath: _aimLineSize
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 96791299733239411, guid: 333d44bb4feca4d4da4ace10c170cea6, type: 3}
-      propertyPath: _renderAimLine
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 96791299733239411, guid: 333d44bb4feca4d4da4ace10c170cea6, type: 3}
-      propertyPath: _renderMaxAimLine
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 96791299733239411, guid: 333d44bb4feca4d4da4ace10c170cea6, type: 3}
       propertyPath: _showPreviewBubble
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 96791299733239411, guid: 333d44bb4feca4d4da4ace10c170cea6, type: 3}
-      propertyPath: _useTargetCellForLineRender
-      value: 0
+      propertyPath: _showDebugCollisionPoints
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3073924807551377228, guid: 333d44bb4feca4d4da4ace10c170cea6, type: 3}
       propertyPath: m_Name

--- a/Assets/_Project/Code/Scripts/GridSystem.cs
+++ b/Assets/_Project/Code/Scripts/GridSystem.cs
@@ -45,6 +45,9 @@ public class GridSystem : MonoBehaviour
     private float _cellSize;
     private GridDimensions _gridDimensions;
     private int _totalCells;
+    private int _maxRows = 15;
+    private int _maxNarrowColumns = 11;
+    private int _maxWideColumns = 16;
     
     [SerializeField] private int _currentLevel = 1;
     [SerializeField] private int _maxRowGeneration = 8;
@@ -71,8 +74,8 @@ public class GridSystem : MonoBehaviour
         ClearGrid();
 
         _cellSize = Bubble.BubbleScale;
-        _gridDimensions.MaxRows = 14;
-        _gridDimensions.MaxColumns = _gridWidth == GridWidth.Narrow ? 11 : 16;
+        _gridDimensions.MaxRows = _maxRows;
+        _gridDimensions.MaxColumns = _gridWidth == GridWidth.Narrow ? _maxNarrowColumns : _maxWideColumns;
         _totalCells = GetTotalCells(_gridDimensions.MaxRows, _gridDimensions.MaxColumns);
         _grid = new GameObject[_gridDimensions.MaxRows][];
 

--- a/Assets/_Project/Level/Prefabs/Debug.meta
+++ b/Assets/_Project/Level/Prefabs/Debug.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 718779b50fc1ea54ab7131e3b9787f2b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Level/Prefabs/Debug/Debug Point.prefab
+++ b/Assets/_Project/Level/Prefabs/Debug/Debug Point.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7024554868288133723
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2250496186953402566}
+  - component: {fileID: 4547926565654950503}
+  m_Layer: 0
+  m_Name: Debug Point
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2250496186953402566
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7024554868288133723}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &4547926565654950503
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7024554868288133723}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 10
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/Assets/_Project/Level/Prefabs/Debug/Debug Point.prefab.meta
+++ b/Assets/_Project/Level/Prefabs/Debug/Debug Point.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1d0c3ae57e94297409a604cae821e4b3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Level/Prefabs/Launcher.prefab
+++ b/Assets/_Project/Level/Prefabs/Launcher.prefab
@@ -165,6 +165,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _showPreviewBubble: 0
+  _renderAimLine: 1
+  _renderMaxAimLine: 1
+  _aimLineLength: 2
+  _showDebugCollisionPoints: 0
+  _debugCollisionPointPrefab: {fileID: 7024554868288133723, guid: 1d0c3ae57e94297409a604cae821e4b3, type: 3}
   _rotateSpeed: 100
   _maxRotationDegrees: 60
   _launchSpeed: 10
@@ -172,7 +177,6 @@ MonoBehaviour:
   _bubbleSlot: {fileID: 173441063}
   _bubblePrefab: {fileID: 997117890731797050, guid: 62c3ced70b290c6418a3d048766d7f0f, type: 3}
   _topBoundaryTag: TopBoundary
-  _bubbleTag: Bubble
   _cellTag: Cell
 --- !u!114 &96791299733239412
 MonoBehaviour:


### PR DESCRIPTION
- resolve issue allowing player to aim past bubbles if the final row in the grid is filled up
- resolve issue causing the launch path to not update after launching a bubble if the rotation of the launcher hasn't changed
- add another row to the grid system to account for out of bounds bubbles